### PR TITLE
Adds Python 3.5.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.5.0"
+  - 3.5
 
 before_install:
   - pip install codecov    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/wtsi-hgi/python-sequencescape-db.git@94bf380ec93e1adc4241fdf176bebf14548f39ad#egg=sequencescape
-git+https://github.com/wtsi-hgi/python-baton-wrapper.git@a97af16b1435c8693c48aa6dfcc889e6c916f933#egg=baton
+git+https://github.com/wtsi-hgi/python-baton-wrapper.git@83cbe7839f426d4a3cc2d1f493352d7dbae127cf#egg=baton
 git+https://github.com/wtsi-hgi/python-sam-header-parser.git@6ea6fa8d72b5c07edae380db2e32d20f5b47463f#egg=sam_header_parser
-hgicommon==1.1.0
+hgicommon==1.2.0
 PyHamcrest==1.8.5
 pbr==1.8.1
-hgijson==1.3.1
+hgijson==1.4.3


### PR DESCRIPTION
Updated versions of in-house libraries used to support Python 3.5.2. Also reversed change in https://github.com/wtsi-hgi/metadata-check/commit/5ff260b9e45e8ba8249aba9f1689d640d4b12d82 to keep Travis CI testing to latest version of Python.